### PR TITLE
Fixed the issue of not redirecting to syllabus

### DIFF
--- a/features/views.py
+++ b/features/views.py
@@ -25,4 +25,7 @@ def teacherFeatures(request):
 
 @login_required
 def suggestedvideos(request):
-    return render(request, "features/suggestedvideos.html")  
+    cur_course = request.COOKIES.get('course_name')
+    syllabus=sylabus.objects.filter(course_name = cur_course).first()
+    context = {"syllabus":syllabus}
+    return render(request, "features/suggestedvideos.html", context)  


### PR DESCRIPTION
When the user is in the reference videos and placed syllabus on navbar the page would just reload. This was becuase the "context" variable was missing in features/views.py
This commit fixes #4 